### PR TITLE
Added config option for table names

### DIFF
--- a/src/Http/Middleware/SpatiePermissionMiddleware.php
+++ b/src/Http/Middleware/SpatiePermissionMiddleware.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Facades\Schema;
 class SpatiePermissionMiddleware
 {
     public function handle($request, Closure $next) {
-        if (!Schema::hasTable('roles') || !Schema::hasTable('permissions')) {
+        $tableNames = config('permission.table_names');
+        
+        if (!Schema::hasTable($tableNames['roles']) || !Schema::hasTable($tableNames['permissions'])) {
             throw new \Exception('Spatie Laravel Permission package is not configured: missing roles/permissions DB tables');
         }
 


### PR DESCRIPTION
Changed the middleware to use the spatie `permission` config to get the table names. This will allow for anyone that has installed and configured the `laravel-permission` package in advanced to still be able to use this package.